### PR TITLE
Update bentopdf repo

### DIFF
--- a/bentopdf/bentopdf.xml
+++ b/bentopdf/bentopdf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>bentopdf</Name>
-  <Repository>bentopdfteam/bentopdf</Repository>
+  <Repository>ghcr.io/alam00000/bentopdf:latest</Repository>
   <Registry>https://hub.docker.com/r/bentopdf/bentopdf/</Registry>
   <Network>bridge</Network>
   <MyIP/>

--- a/bentopdf/bentopdf.xml
+++ b/bentopdf/bentopdf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>bentopdf</Name>
-  <Repository>bentopdf/bentopdf</Repository>
+  <Repository>bentopdfteam/bentopdf</Repository>
   <Registry>https://hub.docker.com/r/bentopdf/bentopdf/</Registry>
   <Network>bridge</Network>
   <MyIP/>


### PR DESCRIPTION
Updated template to point to ghcr.io repository. Dockerhub bentopdf/bentopdf repo is no longer under the creator's control.